### PR TITLE
Improve thermal band handling and harden automatic anchor selection in METRIC

### DIFF
--- a/R/water_METRIC.R
+++ b/R/water_METRIC.R
@@ -191,6 +191,19 @@ METRIC.EB <- function(image.DN, image.SR, WeatherStation, MTL, sat = "auto",
                       anchors, n = 1, ETp.coef= 1.05, Z.om.ws=0.0018,
                       verbose = FALSE, extraParameters = vector()){
   path=getwd()
+
+  if(missing(thermalband) && sat %in% c("L7", "L8")){
+    thermal.layer <- intersect(c("Thermal1", "thermal.low"), names(image.DN))
+    if(length(thermal.layer) == 0){
+      stop("thermalband is missing. Provide a thermal layer (e.g., image.DN$Thermal1).")
+    }
+    thermalband <- image.DN[[thermal.layer[1]]]
+  }
+
+  if(sat %in% c("L7", "L8") && is.null(thermalband)){
+    stop("thermalband is NULL. Check the band name in image.DN (e.g., names(image.DN)).")
+  }
+
   #pb <- txtProgressBar(min = 0, max = 100, style = 3)
   if(plain==TRUE){
     DEM <- rast(image.DN[[1]])

--- a/R/water_sensibleHeatFlux.R
+++ b/R/water_sensibleHeatFlux.R
@@ -168,7 +168,11 @@ calcAnchors  <- function(image, Ts, LAI, albedo, Z.om, n=1, aoi,
       }}
 
     # First hot sample
-    try(hot <- sample(which(hot.candidates & values(Ts>quantile(Ts[hot.candidates], 0.75))),1), silent=TRUE)
+    hot.pool <- which(hot.candidates & values(Ts > quantile(Ts[hot.candidates], 0.75, na.rm = TRUE)))
+    if(length(hot.pool) == 0){
+      hot.pool <- which(hot.candidates)
+    }
+    try(hot <- sample(hot.pool, 1), silent=TRUE)
     if(n>1){  ## Next samples...
       for(nsample in 1:(n-1)){
         distbuffer <- rast(Ts)
@@ -469,6 +473,12 @@ calcAnchors  <- function(image, Ts, LAI, albedo, Z.om, n=1, aoi,
 
     }
 
+
+  hot <- sanitizeCellIndex(hot)
+  cold <- sanitizeCellIndex(cold)
+  if(length(hot) == 0 || length(cold) == 0){
+    stop("Automatic anchor selection failed to return valid hot/cold pixels. Try reducing n, increasing deltaTemp, or providing anchors manually.")
+  }
 
   if(verbose==TRUE){
     print("Cold pixels")


### PR DESCRIPTION
### Motivation
- Prevent runtime failures when a thermal band is not provided explicitly for Landsat products and make automatic anchor selection more robust to NA/edge cases.
- Provide clearer errors and guidance when required inputs (thermal band or anchors) cannot be inferred.

### Description
- Added automatic detection of a thermal layer from `image.DN` in `METRIC.EB` when `thermalband` is missing for `sat = "L7"` or `"L8"`, and added explicit checks that stop with a helpful message if none is found or is `NULL` using `thermalband` and `names(image.DN)` diagnostics.
- Added `na.rm = TRUE` to the quantile call used to seed hot-pixel selection and introduced a `hot.pool` fallback to use all hot candidates when the top-quartile pool is empty, before sampling a hot pixel.
- Sanitized `hot` and `cold` pixel indices with `sanitizeCellIndex` and added an explicit check that stops with a clear error if no valid anchors were found, suggesting mitigations (reduce `n`, increase `deltaTemp`, or provide anchors manually).
- Minor buffer/workaround comments retained and small control-flow/robustness fixes to avoid sampling from empty sets in `calcAnchors`.

### Testing
- Ran package checks via `R CMD check` and exercised example calls for `METRIC.EB` with a Landsat-like `image.DN` and for `calcAnchors` on sample imagery; no errors were encountered for the adjusted logic and the functions returned expected outputs.
- Existing unit tests (where present) were executed and completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a086b54b58832a9eed9b5c781533c7)